### PR TITLE
Apply gs corrections

### DIFF
--- a/process.py
+++ b/process.py
@@ -150,7 +150,7 @@ def build_self_reference(filename,wcslist=None):
 def shift_exposure(filename, old_gs, new_gs, wcsname="TWEAK_GAIA_GSC",
                     deltaRA=None, deltaDEC=None):
     """Update exposure WCS based on guide star coord update.
-    
+
     Parameters
     ===========
     filename : str or HDUList
@@ -1032,7 +1032,7 @@ def apply_shifts(event):
     deltaSCALE=float(refXMLtree.findtext('deltaSCALE'))
 
     old_gs = (float(refXMLtree.findtext('dGSinputRA')),float(refXMLtree.findtext('dGSinputDEC')))
-    new_gs = (float(refXMLtree.findtext('dGSoutputRA'))float(refXMLtree.findtext('dGSoutputDEC')))
+    new_gs = (float(refXMLtree.findtext('dGSoutputRA')),float(refXMLtree.findtext('dGSoutputDEC')))
 
     # Update file with astrometric GS corrections
     wcsName = 'AWSUpdate'


### PR DESCRIPTION
The initial crude update is now replaced by a fully accurate, astropy Coord-based update based on the GS information provided by the database request for any given exposure.  This functionality has been pulled over from what was being used by Brian in the database code for computing the a priori corrections.  All secondary functions have also been added to minimize the amount of external dependencies for this code. 

**NOTE:**
This update **does not** do anything about computing the correct WCSNAME or HDRNAME or any other information necessary for producing a correctly self-documenting headerlet for this a priori correction.  It also **does not** implement the call to pass this new solution back to the astrometry database. 